### PR TITLE
fix: Correctly count *pairs* in FXT_ARG_LIST macro

### DIFF
--- a/include/fxt/record_args.h
+++ b/include/fxt/record_args.h
@@ -213,21 +213,21 @@ struct RecordArgument {
 
 // Implementation macros for different pair counts
 #define FXT_INTERNAL_SELECT_0(fn, ...) /* empty */
-#define FXT_INTERNAL_SELECT_1(fn, ...) /* empty */
-#define FXT_INTERNAL_SELECT_2(fn, a, b, ...) fn(a, b)
-#define FXT_INTERNAL_SELECT_3(fn, a, b, ...) fn(a, b)
-#define FXT_INTERNAL_SELECT_4(fn, a, b, c, d, ...) fn(a, b), fn(c, d)
-#define FXT_INTERNAL_SELECT_5(fn, a, b, c, d, ...) fn(a, b), fn(c, d)
-#define FXT_INTERNAL_SELECT_6(fn, a, b, c, d, e, f, ...) fn(a, b), fn(c, d), fn(e, f)
-#define FXT_INTERNAL_SELECT_7(fn, a, b, c, d, e, f, ...) fn(a, b), fn(c, d), fn(e, f)
-#define FXT_INTERNAL_SELECT_8(fn, a, b, c, d, e, f, g, h, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h)
-#define FXT_INTERNAL_SELECT_9(fn, a, b, c, d, e, f, g, h, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h)
-#define FXT_INTERNAL_SELECT_10(fn, a, b, c, d, e, f, g, h, i, j, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j)
-#define FXT_INTERNAL_SELECT_11(fn, a, b, c, d, e, f, g, h, i, j, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j)
-#define FXT_INTERNAL_SELECT_12(fn, a, b, c, d, e, f, g, h, i, j, k, l, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l)
-#define FXT_INTERNAL_SELECT_13(fn, a, b, c, d, e, f, g, h, i, j, k, l, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l)
-#define FXT_INTERNAL_SELECT_14(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n)
-#define FXT_INTERNAL_SELECT_15(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n)
+#define FXT_INTERNAL_SELECT_1(fn, a, b, ...) fn(a, b)
+#define FXT_INTERNAL_SELECT_2(fn, a, b, c, d, ...) fn(a, b), fn(c, d)
+#define FXT_INTERNAL_SELECT_3(fn, a, b, c, d, e, f, ...) fn(a, b), fn(c, d), fn(e, f)
+#define FXT_INTERNAL_SELECT_4(fn, a, b, c, d, e, f, g, h, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h)
+#define FXT_INTERNAL_SELECT_5(fn, a, b, c, d, e, f, g, h, i, j, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j)
+#define FXT_INTERNAL_SELECT_6(fn, a, b, c, d, e, f, g, h, i, j, k, l, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l)
+#define FXT_INTERNAL_SELECT_7(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n)
+#define FXT_INTERNAL_SELECT_8(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p)
+#define FXT_INTERNAL_SELECT_9(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r)
+#define FXT_INTERNAL_SELECT_10(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r), fn(s, t)
+#define FXT_INTERNAL_SELECT_11(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r), fn(s, t), fn(u, v)
+#define FXT_INTERNAL_SELECT_12(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r), fn(s, t), fn(u, v), fn(w, x)
+#define FXT_INTERNAL_SELECT_13(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r), fn(s, t), fn(u, v), fn(w, x), fn(y, z)
+#define FXT_INTERNAL_SELECT_14(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, ab, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r), fn(s, t), fn(u, v), fn(w, x), fn(y, z), fn(aa, ab)
+#define FXT_INTERNAL_SELECT_15(fn, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, ab, ac, ad, ...) fn(a, b), fn(c, d), fn(e, f), fn(g, h), fn(i, j), fn(k, l), fn(m, n), fn(o, p), fn(q, r), fn(s, t), fn(u, v), fn(w, x), fn(y, z), fn(aa, ab), fn(ac, ad)
 
 // Helper macros for indirection and selection
 #define FXT_INTERNAL_SELECT_HELPER(N) FXT_INTERNAL_SELECT_##N
@@ -237,7 +237,7 @@ struct RecordArgument {
  * Applies the given fn to each pair of arguments
  */
 #define FXT_INTERNAL_APPLY_PAIRWISE_CSV(fn, ...) \
-	FXT_INTERNAL_EXPAND3(FXT_INTERNAL_SELECT(FXT_INTERNAL_EXPAND(FXT_INTERNAL_COUNT_PAIRS(__VA_ARGS__)))(fn, __VA_ARGS__))
+	FXT_INTERNAL_EXPAND3(FXT_INTERNAL_SELECT(FXT_INTERNAL_EXPAND(FXT_INTERNAL_COUNT_PAIRS(__VA_ARGS__)))(fn, __VA_ARGS__, nullptr))
 
 #define FXT_INTERNAL_DECLARE_ARG(name, value) \
 	fxt::RecordArgument(name, fxt::RecordArgumentValue(value))

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(SRC_FILES
 	${PROJECT_SOURCE_DIR}/tests/src/main.cpp
+	${PROJECT_SOURCE_DIR}/tests/src/record_args.cpp
 	${PROJECT_SOURCE_DIR}/tests/src/write.cpp
 	${PROJECT_SOURCE_DIR}/tests/src/writer_test.h
 	${PROJECT_SOURCE_DIR}/tests/src/writer_validation.h

--- a/tests/src/record_args.cpp
+++ b/tests/src/record_args.cpp
@@ -1,0 +1,61 @@
+/* FXT - A library for creating Fuschia Tracing System (FXT) files
+ *
+ * FXT is the legal property of Adrian Astley
+ * Copyright Adrian Astley 2023
+ */
+
+#include "fxt/record_args.h"
+
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_string.hpp"
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+TEST_CASE("TestArgumentMacroExpansion", "[write]") {
+	auto countArgs = [](std::initializer_list<fxt::RecordArgument> args) {
+		return args.size();
+	};
+
+	REQUIRE(countArgs(FXT_ARG_LIST("arg1", 10)) == 1);
+	REQUIRE(countArgs(FXT_ARG_LIST("arg1", 10, "arg2", 20)) == 2);
+	REQUIRE(countArgs(FXT_ARG_LIST("arg1", 10, "arg2", 20, "arg3", 30, "arg4", 40, "arg5", 50)) == 5);
+	REQUIRE(countArgs(FXT_ARG_LIST("arg1", 10, "arg2", 20, "arg3", 30, "arg4", 40, "arg5", 50, "arg6", 60, "arg7", 70, "arg8", 80, "arg9", 90, "arg10", 100)) == 10);
+}
+
+TEST_CASE("TestArgumentMacroExpansionContent", "[write]") {
+	auto toVector = [](std::initializer_list<fxt::RecordArgument> args) {
+		return std::vector<fxt::RecordArgument>(args);
+	};
+
+	const auto args = toVector(FXT_ARG_LIST("count", 7, "enabled", true, "label", "alpha", "big", (uint64_t)42, "value", 3.5));
+
+	REQUIRE(args.size() == 5);
+
+	REQUIRE(args[0].name.nameLen == 5);
+	REQUIRE_THAT(std::string(args[0].name.name, args[0].name.nameLen), Catch::Matchers::Equals("count"));
+	REQUIRE(args[0].value.type == fxt::internal::ArgumentType::Int32);
+	REQUIRE(args[0].value.int32Value == 7);
+
+	REQUIRE(args[1].name.nameLen == 7);
+	REQUIRE_THAT(std::string(args[1].name.name, args[1].name.nameLen), Catch::Matchers::Equals("enabled"));
+	REQUIRE(args[1].value.type == fxt::internal::ArgumentType::Bool);
+	REQUIRE(args[1].value.boolValue == true);
+
+	REQUIRE(args[2].name.nameLen == 5);
+	REQUIRE_THAT(std::string(args[2].name.name, args[2].name.nameLen), Catch::Matchers::Equals("label"));
+	REQUIRE(args[2].value.type == fxt::internal::ArgumentType::String);
+	REQUIRE(args[2].value.stringLen == 5);
+	REQUIRE_THAT(std::string(args[2].value.stringValue, args[2].value.stringLen), Catch::Matchers::Equals("alpha"));
+
+	REQUIRE(args[3].name.nameLen == 3);
+	REQUIRE_THAT(std::string(args[3].name.name, args[3].name.nameLen), Catch::Matchers::Equals("big"));
+	REQUIRE(args[3].value.type == fxt::internal::ArgumentType::UInt64);
+	REQUIRE(args[3].value.uint64Value == 42);
+
+	REQUIRE(args[4].name.nameLen == 5);
+	REQUIRE_THAT(std::string(args[4].name.name, args[4].name.nameLen), Catch::Matchers::Equals("value"));
+	REQUIRE(args[4].value.type == fxt::internal::ArgumentType::Double);
+	REQUIRE(args[4].value.doubleValue == 3.5);
+}


### PR DESCRIPTION
The previous code was assuming pair counts, but actually only counting args. Which meant the resulting initialization_list was the wrong count